### PR TITLE
Dependencies had build step disabled

### DIFF
--- a/TSOClient/tso.client.sln
+++ b/TSOClient/tso.client.sln
@@ -472,6 +472,7 @@ Global
 		{25A5DA9E-88E8-4BC2-AE80-45935276790E}.Android|x86.ActiveCfg = Release|Any CPU
 		{25A5DA9E-88E8-4BC2-AE80-45935276790E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{25A5DA9E-88E8-4BC2-AE80-45935276790E}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{25A5DA9E-88E8-4BC2-AE80-45935276790E}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
 		{25A5DA9E-88E8-4BC2-AE80-45935276790E}.Debug|x86.ActiveCfg = Debug|Any CPU
 		{25A5DA9E-88E8-4BC2-AE80-45935276790E}.iOS|Any CPU.ActiveCfg = Release|Any CPU
 		{25A5DA9E-88E8-4BC2-AE80-45935276790E}.iOS|Mixed Platforms.ActiveCfg = Release|Any CPU
@@ -499,6 +500,7 @@ Global
 		{07F742C5-C66A-4D1E-A761-458E08D4E302}.Android|x86.ActiveCfg = Release|Any CPU
 		{07F742C5-C66A-4D1E-A761-458E08D4E302}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{07F742C5-C66A-4D1E-A761-458E08D4E302}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{07F742C5-C66A-4D1E-A761-458E08D4E302}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
 		{07F742C5-C66A-4D1E-A761-458E08D4E302}.Debug|x86.ActiveCfg = Debug|Any CPU
 		{07F742C5-C66A-4D1E-A761-458E08D4E302}.iOS|Any CPU.ActiveCfg = Release|Any CPU
 		{07F742C5-C66A-4D1E-A761-458E08D4E302}.iOS|Mixed Platforms.ActiveCfg = Release|Any CPU


### PR DESCRIPTION
Hey,

I'm trying to setup a continuous integration server for PD so it builds automatically. Final hurdle is the project actively disables GonzoNet & the Protocol lib from compiling. This makes it impossible to compile the project with msbuild.

In visual studio you currently have to build those libs first and then build tso.client (as 2 manual steps) which is difficult to represent in msbuild.exe. 